### PR TITLE
Fix for working in web workers.

### DIFF
--- a/src/jdataview.js
+++ b/src/jdataview.js
@@ -296,7 +296,7 @@ for (var type in dataTypes) {
 				// ArrayBuffer: we use a typed array of size 1 if the alignment is good
 				// ArrayBuffer does not support endianess flag (for size > 1)
 				else if (this._isArrayBuffer && byteOffset % size == 0 && (size == 1 || littleEndian)) {
-					value = new window[type + 'Array'](this._buffer, byteOffset, 1)[0];
+					value = new self[type + 'Array'](this._buffer, byteOffset, 1)[0];
 				}
 				else {
 					// Error Checking
@@ -317,6 +317,6 @@ for (var type in dataTypes) {
 	})(type);
 }
 
-window.jDataView = jDataView;
+self.jDataView = jDataView;
 
 })();


### PR DESCRIPTION
The global context in web workers is not "window" since that is only for pages with DOM. "self" is the global context for both.
