### PR TITLE
Rename forgotten changed variable name

### DIFF
--- a/src/jdataview.js
+++ b/src/jdataview.js
@@ -315,7 +315,7 @@ for (var type in dataTypes) {
 				// ArrayBuffer: we use a typed array of size 1 if the alignment is good
 				// ArrayBuffer does not support endianess flag (for size > 1)
 				else if (this._isArrayBuffer && (this._start + byteOffset) % size === 0 && (size === 1 || littleEndian)) {
-					value = new all[type + 'Array'](this.buffer, this._start + byteOffset, 1)[0];
+					value = new global[type + 'Array'](this.buffer, this._start + byteOffset, 1)[0];
 				}
 				// NodeJS Buffer
 				else if (this._isNodeBuffer && compatibility.NodeBufferFull) {


### PR DESCRIPTION
When using ArrayBuffer, the "all" variable should be changed to "global". I guess it was forgotten in the "One-line export" commit: https://github.com/vjeux/jDataView/commit/9ae737187880f009b8f6b2dde1c5f979488c8dfa
