### PR TITLE
Use `module` instead of `global.module` when exporting

### DIFF
--- a/src/jdataview.js
+++ b/src/jdataview.js
@@ -446,6 +446,6 @@ if (typeof jQuery !== 'undefined' && jQuery.fn.jquery >= "1.6.2") {
 	});
 }
 
-global.jDataView = (global.module || {}).exports = jDataView;
+global.jDataView = (module || {}).exports = jDataView;
 
 })(this);


### PR DESCRIPTION
Today I tried jParser in Node v0.6.16 and it failed with errors like `TypeError: Expecting a function in instanceof check` and `TypeError: object is not a function` in the following code (`jparser.js`, line 25 and below):

``` javascript
if (!(view instanceof jDataView)) {
   view = new jDataView(view);
}
```

(You get `TypeError: object is not a function` instead of `TypeError: Expecting a function in instanceof check` if you erase the `if` and leave only `view = new jDataView(view)`.)

Then I tried `console.log(jDataView)` from within function `jParser` (`jparser.js`, line 25) and got `{ jDataView: { [Function] createBuffer: [Function] } }` instead of the expected `{ [Function] createBuffer: [Function] }` output. In other words, Node.js thinks of `jDataView` as of a function within an object of the same name, not as of a constructor.

After futher testing I found that using `module` instead of `global.module` (in `jdataview.js`, line 449) eliminates all errors (though I am not 100% sure why), and here I am requesting a pull.
