### PR TITLE
Optimizations + getBytes method

### DIFF
--- a/src/jdataview.js
+++ b/src/jdataview.js
@@ -267,7 +267,7 @@ jDataView.prototype = {
             result.reverse();
         }
 
-        this._offset = byteOffset + length;
+        this._offset = byteOffset - this._start + length;
 
         return result;
     },


### PR DESCRIPTION
Different optimizations using new getBytes endian-aware method and faster constructors.
It does not pass getString/getChar tests, but as far as I understood - non-ANSI characters were for some reason replaced with Unicode NULL character (0xFFFF) and I think it's better to support full 0..255 range so transformation could be done in both directions w/o byte loss.
