### PR TITLE
Opera fix

### DIFF
--- a/src/jdataview.js
+++ b/src/jdataview.js
@@ -496,6 +496,8 @@ jDataView.prototype = {
 	setBytes: function (byteOffset, bytes, littleEndian) {
 		var length = bytes.length;
 
+		if (length === 0) return;
+
 		// Handle the lack of endianness
 		if (littleEndian === undefined) {
 			littleEndian = this._littleEndian;


### PR DESCRIPTION
Opera throws RangeError: Offset larger than array size if trying to create Uint8Array view with zero length.
