### PR TITLE
Handle replacing global.DataView with jDataView

### DIFF
--- a/src/jdataview.js
+++ b/src/jdataview.js
@@ -78,7 +78,7 @@ function jDataView(buffer, byteOffset, byteLength, littleEndian) {
 	// Check parameters and existing functionnalities
 	this._isArrayBuffer = compatibility.ArrayBuffer && is(buffer, ArrayBuffer);
 	this._isPixelData = BROWSER && compatibility.PixelData && is(buffer, CanvasPixelArray);
-	this._isDataView = compatibility.DataView && this._isArrayBuffer;
+	this._isDataView = compatibility.DataView && this._isArrayBuffer && global.DataView !== jDataView;
 	this._isNodeBuffer = NODE && compatibility.NodeBuffer && Buffer.isBuffer(buffer);
 
 	// Handle Type Errors

--- a/test/test.js
+++ b/test/test.js
@@ -532,3 +532,11 @@ engines.forEach(function (engineName) {
 		});
 	});
 });
+
+test('replacing global.DataView', function () {
+	var orig = global.DataView;
+	global.DataView = jDataView;
+	new DataView(new ArrayBuffer(3));
+	global.DataView = orig;
+});
+


### PR DESCRIPTION
I'm sorry if I don't really understand your testing system. When I stuck the test inside your loop of "engines" it failed and I wasn't really following why. When I moved it outside things worked. 

The test fails without the change and passes with it. 

BTW, Replacing builtins in a standard and normal feature of JavaScript. That's how it works without breaking everytime node or the browsers add a new global. 

You create a class named say `AudioBuffer`. You put your code on the web. Next year the browsers add a new API and add a native `AudioBuffer` class. If your class didn't override their new class then everytime browsers added new classes they'd be breaking 1000s of sites.


#84 