### PR TITLE
Readme & stylistic updates for 3.0.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Tests
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-* **October X 2023**
+* **December 2023**
   * Version 3.0.0
   * jDataView no longer polyfills DataView, it uses the native implementation. The install and bundle sizes will be better now.
   * Build system is now run by Vite, with testing using Vitest and Github Actions.
   * jDataView is now published as ES modules.
   * TypeScript support.
+  * BigInt support.
 * **April 14 2014**
   * Build process completely reworked and automated via Grunt + Travis CI.
 * **August 23 2013**

--- a/README.md
+++ b/README.md
@@ -1,31 +1,50 @@
-[![Build Status](https://travis-ci.org/jDataView/jDataView.png?branch=master)](https://travis-ci.org/jDataView/jDataView)
-[![NPM version](https://badge.fury.io/js/jdataview.png)](https://npmjs.org/package/jdataview)
-[jDataView](http://blog.vjeux.com/2011/javascript/jdataview-read-binary-file.html) - A unique way to work with a binary file in JavaScript.
-================================
+# jDataView - JS Binary data made easy
 
-jDataView provides a layer on top of `DataView` to make modifying binary data a pleasure.
+[![Tests Status](https://github.com/jdataview/jdataview/actions/workflows/run-tests.yml/badge.svg)](https://github.com/jDataView/jDataView/actions/workflows/run-tests.yml)
 
-jDataView is a drop-in replacement for the native `DataView`, adding methods for setting string, arbitrary-sized integers, and more.
+[npm](https://www.npmjs.com/package/jdataview) | [GitHub](https://github.com/jDataView/jDataView/) | [Docs](https://github.com/jDataView/jDataView/wiki) | [Website](https://jdataview.github.io/jDataView/) | [Changelog](https://github.com/jDataView/jDataView/blob/master/CHANGELOG.md)
+
+jDataView is a drop-in replacement for JavaScript's built-in `DataView` class,  adding methods for writing strings, individual bits, arbitrary-sized integers, and more.
+
+## Usage
+
+```bash
+npm i jdataview
+```
+> Note that TypeScript definitions are now included in the `jDataView` package automatically.
+```ts
+import { jDataView } from "jDataView";
+
+const view = new jDataView(new ArrayBuffer(100));
+
+const msg = "Hello there";
+
+view.writeString(msg);
+view.writeBigInt64(2011n);
+
+view.seek(0);
+console.log(view.getString(msg.length)); // Hello there
+console.log(view.getBigInt64()); // 2011n (the year jDataView was created)
+```
+More examples are in [the docs](). Here's a [starting point](https://github.com/jDataView/jDataView/wiki/Example).
+
+## [Documentation](https://github.com/jDataView/jDataView/wiki)
+jDataView extends the built-in JavaScript `DataView` class, so all of [it's documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) is applicable here. 
+
+### API Reference
+
+  * [jDataView constructor](https://github.com/jDataView/jDataView/wiki/jDataView-constructor)
+  * jDataView Extensions
+    * [Operation control](https://github.com/jDataView/jDataView/wiki/Operation-control)
+    * [writeXXX methods](https://github.com/jDataView/jDataView/wiki/writeXXX-methods)
+    * [Strings and Blobs](https://github.com/jDataView/jDataView/wiki/Strings-and-Blobs)
+    * [Bitfields](https://github.com/jDataView/jDataView/wiki/Bitfields)
+    * [Internal utilities](https://github.com/jDataView/jDataView/wiki/Internal-utilities)
 
 
-Documentation
-=============
+## History
 
-  * API
-    * [jDataView constructor](https://github.com/jDataView/jDataView/wiki/jDataView-constructor)
-    * [DataView documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)
-    * Extensions
-      * [Operation control](https://github.com/jDataView/jDataView/wiki/Operation-control)
-      * [writeXXX methods](https://github.com/jDataView/jDataView/wiki/writeXXX-methods)
-      * [Strings and Blobs](https://github.com/jDataView/jDataView/wiki/Strings-and-Blobs)
-      * [Bitfields](https://github.com/jDataView/jDataView/wiki/Bitfields)
-      * [Internal utilities](https://github.com/jDataView/jDataView/wiki/Internal-utilities)
-  * [Example](https://github.com/jDataView/jDataView/wiki/Example)
-  * [Changelog](https://github.com/jDataView/jDataView/blob/master/CHANGELOG.md)
-
-
-History
-===========
+Check out the original [jDataView article](https://blog.vjeux.com/2011/javascript/jdataview-read-binary-file.html) by [Vjeux](https://github.com/vjeux), jDataView's original author.
 
 There are three ways to read a binary file from the browser.
 
@@ -45,8 +64,30 @@ And one way to read a binary file from the server.
 
 Now that `DataView` is natively available in all engines, **jDataView 3** acts as a layer on top of it with powerful methods for dealing with non-standard binary data types, such as strings and arbitrary-sized integers.
 
-Also check out ([jBinary](https://github.com/jDataView/jBinary))
-========================
+## Demos
+
+- [PhotoSynth WebGL Viewer](http://www.visual-experiments.com/2011/04/05/photosynth-webgl-viewer/) by Visual Experiments. It uses jDataView to read the binary file and then WebGL to display it.
+- [simple tar viewer](http://jdataview.github.io/jDataView/untar/). It is a "Hello World" demo of how easy it is to use the library.
+- [TrueTypeFont library demo](http://ynakajima.github.io/ttf.js/demo/glyflist/) which uses jDataView to read and display glyphs from TrueType file.
+- [jBinary.Repo](https://jdataview.github.io/jBinary.Repo) ready-to-use typesets and corresponding demos of using
+[jDataView](https://github.com/jDataView/jDataView)+[jBinary](https://github.com/jDataView/jBinary)
+for reading popular file formats like
+[GZIP archives](https://jdataview.github.io/jBinary.Repo/demo/#gzip),
+[TAR archives](https://jdataview.github.io/jBinary.Repo/demo/#tar),
+[ICO images](https://jdataview.github.io/jBinary.Repo/demo/#ico),
+[BMP images](https://jdataview.github.io/jBinary.Repo/demo/#bmp),
+[MP3 tags](https://jdataview.github.io/jBinary.Repo/demo/#mp3)
+etc.
+- [Talking image](http://hacksparrow.github.io/talking-image/) - animation and audio in one package powered by
+HTML5 Audio, [jDataView](https://github.com/jDataView/jDataView) and [jBinary](https://github.com/jDataView/jBinary).
+
+---
+
+*Please tell us if you made something with jDataView :)*
+
+
+## Also check out [jBinary](https://github.com/jDataView/jBinary)
+
 
 For complicated binary structures, it may be hard enough to use only low-level get/set operations for parsing,
 processing and writing data.
@@ -58,48 +99,3 @@ or even as simple download link.
 
 If you faced any of these problems, you might want to check out new [jBinary](https://github.com/jDataView/jBinary)
 library that works on top of **jDataView** and allows to operate with binary data in structured and convenient way.
-
-Demos
-=====
-
-[HTTP Live Streaming realtime converter and player demo](http://rreverser.github.io/mpegts/) implemented using [jBinary](https://github.com/jDataView/jBinary) data structures.
-[![Screenshot](http://rreverser.github.io/mpegts/screenshot.png?)](http://rreverser.github.io/mpegts/)
-
----
-
-A [World of Warcraft Model Viewer](http://jdataview.github.io/jsWoWModelViewer/). It uses [jDataView](https://github.com/jDataView/jDataView)+[jBinary](https://github.com/jDataView/jBinary) to read the binary file and then WebGL to display it.
-[![Screenshot](http://jdataview.github.io/jsWoWModelViewer/images/modelviewer.png)](http://jdataview.github.io/jsWoWModelViewer/)
-
----
-
-A [PhotoSynth WebGL Viewer](http://www.visual-experiments.com/2011/04/05/photosynth-webgl-viewer/) by Visual Experiments. It uses jDataView to read the binary file and then WebGL to display it.
-[![Screenshot](http://i.imgur.com/HRHXo.jpg)](http://www.visual-experiments.com/2011/04/05/photosynth-webgl-viewer/)
-
----
-
-A [simple tar viewer](http://jdataview.github.io/jDataView/untar/). It is a "Hello World" demo of how easy it is to use the library.
-
----
-
-JavaScript [TrueTypeFont library demo](http://ynakajima.github.io/ttf.js/demo/glyflist/) which uses jDataView to read and display glyphs from TrueType file.
-
---
-
-[jBinary.Repo](https://jdataview.github.io/jBinary.Repo) ready-to-use typesets and corresponding demos of using
-[jDataView](https://github.com/jDataView/jDataView)+[jBinary](https://github.com/jDataView/jBinary)
-for reading popular file formats like
-[GZIP archives](https://jdataview.github.io/jBinary.Repo/demo/#gzip),
-[TAR archives](https://jdataview.github.io/jBinary.Repo/demo/#tar),
-[ICO images](https://jdataview.github.io/jBinary.Repo/demo/#ico),
-[BMP images](https://jdataview.github.io/jBinary.Repo/demo/#bmp),
-[MP3 tags](https://jdataview.github.io/jBinary.Repo/demo/#mp3)
-etc.
-
----
-
-[Talking image](http://hacksparrow.github.io/talking-image/) - animation and audio in one package powered by
-HTML5 Audio, [jDataView](https://github.com/jDataView/jDataView) and [jBinary](https://github.com/jDataView/jBinary).
-
----
-
-*Please tell us if you made something with jDataView :)*

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm i jdataview
 ```ts
 import { jDataView } from "jDataView";
 
+// jDataView maintains an internal byte-cursor, which lets you use the API in a much more ergonomic way
 const view = new jDataView(new ArrayBuffer(100));
 
 const msg = "Hello there";
@@ -27,13 +28,12 @@ view.writeBigInt64(2011n);
 // seek(pos) changes the byte-position of jDataView's internal 'cursor' 
 view.seek(0);
 
-// You need to specify the byte-length for strings
-// (which for ascii text is just the length)
-console.log(view.getString(msg.length)); // Hello there
+// You need to specify the byte-length for strings (which for ascii text is just the length)
+console.log(view.getString(msg.length)); // > Hello there
 
-// Passing an offset is optional -
-// if you don't, jDataView will use the byte-cursor position
-console.log(view.getBigInt64()); // 2011n (the year jDataView was created)
+// Passing an offset is optional - if you don't, jDataView uses the byte-cursor position
+// jDataView also has methods that let you use bigger Number's than JavaScript supports - you'll just lose precision
+console.log(view.getInt64()); // > 2011
 ```
 More examples are in [the docs](https://github.com/jDataView/jDataView/wiki). Here's a good [starting point](https://github.com/jDataView/jDataView/wiki/Example).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm i jdataview
 ```
 > Note that TypeScript definitions are now included in the `jDataView` package automatically.
 ```ts
-import { jDataView } from "jDataView";
+import { jDataView } from "jdataview";
 
 // jDataView maintains an internal byte-cursor, which lets you use the API in a much more ergonomic way
 const view = new jDataView(new ArrayBuffer(100));

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ jDataView is a drop-in replacement for JavaScript's built-in `DataView` class,  
 ```bash
 npm i jdataview
 ```
-> Note that TypeScript definitions are now included in the `jDataView` package automatically.
+> Note that TypeScript definitions are now included in the `jdataview` package automatically.
 ```ts
 import { jDataView } from "jdataview";
 

--- a/README.md
+++ b/README.md
@@ -50,29 +50,6 @@ jDataView extends the built-in JavaScript `DataView` class, so all of [it's docu
     * [Bitfields](https://github.com/jDataView/jDataView/wiki/Bitfields)
     * [Internal utilities](https://github.com/jDataView/jDataView/wiki/Internal-utilities)
 
-
-## History
-
-Check out the original [jDataView article](https://blog.vjeux.com/2011/javascript/jdataview-read-binary-file.html) by [Vjeux](https://github.com/vjeux), jDataView's original author.
-
-There are three ways to read a binary file from the browser.
-
-* The first one is to download the file through XHR with [charset=x-user-defined](https://developer.mozilla.org/en/using_xmlhttprequest#Receiving_binary_data). You get the file as a **String**, convert it to byte **Array** and you have to rewrite all the decoding and encoding functions (getUint16, getFloat32, ...). All the browsers support this.
-
-* Then browsers that implemented **Canvas** also added **CanvasPixelArray** as part of **ImageData**. It is fast byte array that is created and used internally by `<canvas />` element for manipulating low-level image data. We can create such host element and use it as factory for our own instances of this array.
-
-* Then browsers that implemented **WebGL** added **ArrayBuffer**. It is a plain buffer that can be read with views called **TypedArrays** (Int32Array, Float64Array, ...). You can use them to decode the file but this is not very handy. It has big drawback, it can't read non-aligned data (but we can actually hack that). So they replaced **CanvasPixelArray** with **Uint8ClampedArray** (same as Uint8Array, but cuts off numbers outside 0..255 range).
-
-* A new revision of the specification added **DataViews**. It is a view around your buffer that can read/write arbitrary data types directly through functions: getUint32, getFloat64 ...
-
-And one way to read a binary file from the server.
-
-* **NodeJS Buffers**. They appeared in [Node 0.4.0](http://nodejs.org/docs/v0.4.0/api/buffers.html). [Node 0.5.0](http://nodejs.org/docs/v0.5.0/api/buffers.html) added a DataView-like API. And [Node 0.6.0](http://nodejs.org/docs/v0.6.0/api/buffers.html) changed the API naming convention.
-
-**jDataView** provided a polyfill for the **DataView API** with own convenient extensions using the best available option between Arrays, TypedArrays, NodeJS Buffers and DataViews.
-
-Now that `DataView` is natively available in all engines, **jDataView 3** acts as a layer on top of it with powerful methods for dealing with non-standard binary data types, such as strings and arbitrary-sized integers.
-
 ## Demos
 
 - [PhotoSynth WebGL Viewer](http://www.visual-experiments.com/2011/04/05/photosynth-webgl-viewer/) by Visual Experiments. It uses jDataView to read the binary file and then WebGL to display it.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,23 @@ const view = new jDataView(new ArrayBuffer(100));
 
 const msg = "Hello there";
 
+// jDataView's writeXXX methods are the same as the setXXX methods,
+// but the byte-cursor position is used instead of passing an offset
 view.writeString(msg);
 view.writeBigInt64(2011n);
 
+// seek(pos) changes the byte-position of jDataView's internal 'cursor' 
 view.seek(0);
+
+// You need to specify the byte-length for strings
+// (which for ascii text is just the length)
 console.log(view.getString(msg.length)); // Hello there
+
+// Passing an offset is optional -
+// if you don't, jDataView will use the byte-cursor position
 console.log(view.getBigInt64()); // 2011n (the year jDataView was created)
 ```
-More examples are in [the docs](). Here's a [starting point](https://github.com/jDataView/jDataView/wiki/Example).
+More examples are in [the docs](https://github.com/jDataView/jDataView/wiki). Here's a good [starting point](https://github.com/jDataView/jDataView/wiki/Example).
 
 ## [Documentation](https://github.com/jDataView/jDataView/wiki)
 jDataView extends the built-in JavaScript `DataView` class, so all of [it's documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) is applicable here. 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,56 @@
-# jDataView - JS Binary data made easy
+# jDataView - easy binary data in JavaScript
 
 [![Tests Status](https://github.com/jdataview/jdataview/actions/workflows/run-tests.yml/badge.svg)](https://github.com/jDataView/jDataView/actions/workflows/run-tests.yml)
 
 [npm](https://www.npmjs.com/package/jdataview) | [GitHub](https://github.com/jDataView/jDataView/) | [Docs](https://github.com/jDataView/jDataView/wiki) | [Website](https://jdataview.github.io/jDataView/) | [Changelog](https://github.com/jDataView/jDataView/blob/master/CHANGELOG.md)
 
-jDataView is a drop-in replacement for JavaScript's built-in `DataView` class,  adding methods for writing strings, individual bits, arbitrary-sized integers, and more.
+jDataView is a drop-in replacement for JavaScript's built-in [`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) class, adding methods for writing strings, individual bits, arbitrary-sized integers, and more.
 
-## Usage
-
-```bash
-npm i jdataview
+## Installation
+jDataView is published on [npm](https://www.npmjs.com/package/jdataview), so you may install it like so:
+```sh
+npm add jdataview
 ```
 > Note that TypeScript definitions are now included in the `jdataview` package automatically.
-```ts
+
+## Usage
+`jDataView` functions as a drop-in replacement for the native `DataView` API, with extra features on top:
+```js
 import { jDataView } from "jdataview";
 
-// jDataView maintains an internal byte-cursor, which lets you use the API in a much more ergonomic way
+// Construct jDataView the same way you would construct a regular DataView
+// You may also pass a string or array of numbers, and jDataView will parse
+// that into an ArrayBuffer automatically
 const view = new jDataView(new ArrayBuffer(100));
+// You can also use `const view = jDataView.from(0x00, 0x01, ...etc)`
+
+// The regular methods all work as before
+view.setInt16(0, 256, true);
 
 const msg = "Hello there";
 
-// jDataView's writeXXX methods are the same as the setXXX methods,
+// jDataView maintains an internal byte-cursor, which lets you use
+// the API in a much more ergonomic way. For example, jDataView's
+// writeXXX methods are much the same as the setXXX methods,
 // but the byte-cursor position is used instead of passing an offset
 view.writeString(msg);
 view.writeBigInt64(2011n);
 
-// seek(pos) changes the byte-position of jDataView's internal 'cursor' 
+// seek(pos) changes the byte position of jDataView's internal 'cursor.' 
 view.seek(0);
 
-// You need to specify the byte-length for strings (which for ascii text is just the length)
+// You need to specify the byte length for strings (which for ASCII text is just the length)
 console.log(view.getString(msg.length)); // > Hello there
 
 // Passing an offset is optional - if you don't, jDataView uses the byte-cursor position
-// jDataView also has methods that let you use bigger Number's than JavaScript supports - you'll just lose precision
+// jDataView also has methods that let you use bigger Numbers than JavaScript supports - you'll just lose precision
 console.log(view.getInt64()); // > 2011
 ```
+
 More examples are in [the docs](https://github.com/jDataView/jDataView/wiki). Here's a good [starting point](https://github.com/jDataView/jDataView/wiki/Example).
 
 ## [Documentation](https://github.com/jDataView/jDataView/wiki)
 jDataView extends the built-in JavaScript `DataView` class, so all of [it's documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) is applicable here. 
-
-### API Reference
-
-  * [jDataView constructor](https://github.com/jDataView/jDataView/wiki/jDataView-constructor)
-  * jDataView Extensions
-    * [Operation control](https://github.com/jDataView/jDataView/wiki/Operation-control)
-    * [writeXXX methods](https://github.com/jDataView/jDataView/wiki/writeXXX-methods)
-    * [Strings and Blobs](https://github.com/jDataView/jDataView/wiki/Strings-and-Blobs)
-    * [Bitfields](https://github.com/jDataView/jDataView/wiki/Bitfields)
-    * [Internal utilities](https://github.com/jDataView/jDataView/wiki/Internal-utilities)
 
 ## Demos
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,7 +8,7 @@ export function getCharCodes(string) {
 	return codes;
 }
 
-// mostly internal function for wrapping any supported input (String or Array-like) to best suitable buffer format
+// Internal function for wrapping any supported input (String or Array-like) to an ArrayBuffer
 export function wrapBuffer(buffer) {
 	switch (typeof buffer) {
 		case "number": {


### PR DESCRIPTION
Changes

- Removed images from examples
- Remove broken examples
- Removed blurry npm badge - we can use github releases
- Changed travis CI badge to github actions badge
- Wrote usage example for readme

TODO

- [x] Update history section of readme
- [ ] What's happening with the website? https://jdataview.github.io/jDataView/
- [x] Wiki updates
  - [x] Home page
  - [x] History page
  - [x] 64-bit integers page
  - [x] Bitfields page (Rename)
  - [x] Example page (remove, replace with contextual examples?)
  - [x] Remove Internal utilities page (or rename to extra utilities?) 
  - [x] jDataView constructor page (turn into API reference?)
  - [x] Operation control page (Rename to sequential writes?)
    - [x] Make it clearer that it's about the cursor
    - [x] Move slice to core API reference
  - [x] Specification API page (rename?)
  - [x] Strings and blobs page (do we actually support `Blob`s?)
  - [x] writeXXX methods 


